### PR TITLE
Support embedded structs

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/tristanfisher/patchpanel"
+)
+
+type DatabaseConfig struct {
+	Host     string `default:"localhost"`
+	Port     int    `default:"5432"`
+	Name     string `default:"myDatabase"`
+	User     string `default:"myUser"`
+	Password string `default:"myPassword"`
+	SSLMode  string `default:"disable"`
+}
+
+type Config struct {
+	Runtime    time.Duration `default:"5s"`
+	StringTest string        `default:"hi"`
+	IntValue   int           `default:"42"`
+	DBConfig   DatabaseConfig
+}
+
+func ParseConfig(configPath string, configStruct Config) (*Config, error) {
+	patch := patchpanel.NewPatchPanel(patchpanel.TokenSeparator, patchpanel.KeyValueSeparator)
+
+	// get defaults off of our struct using patchpanel
+	confType := reflect.TypeOf(configStruct)
+	for i := 0; i < confType.NumField(); i++ {
+		fieldVal, err := patch.GetDefault(confType.Field(i).Name, confType, []string{})
+		if err != nil {
+			return &Config{}, err
+		}
+		fmt.Println(confType.Field(i).Name, " => ", fieldVal)
+	}
+	return &configStruct, nil
+}
+
+func main() {
+	// grab a values/configuration file path from our environment using patchpanel
+	valuesFile := patchpanel.GetFileEnvOrPath(patchpanel.ENV_CONFIG_FILE, patchpanel.FLAG_CONFIG_FILE)
+	conf, err := ParseConfig(valuesFile, Config{})
+	if err != nil {
+		_, _ = os.Stderr.WriteString(fmt.Sprintf("error parsing configuration: %s\n", err.Error()))
+		os.Exit(1)
+	}
+	fmt.Println(conf)
+}

--- a/example/example.go
+++ b/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -25,28 +26,53 @@ type Config struct {
 	DBConfig   DatabaseConfig
 }
 
+// populateDefaults recursively loads `default` struct tags into the struct pointed to by structPtr.
+// When a field's type is itself a struct with no registered type parser, the struct KindParser
+// returns NoValueError; populateDefaults treats this as a signal to recurse into that field.
+func populateDefaults(patch *patchpanel.PatchPanel, structPtr reflect.Value) error {
+	v := structPtr.Elem()
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldVal := v.Field(i)
+
+		val, err := patch.GetDefault(field.Name, t, []string{})
+		if err != nil {
+			var noVal patchpanel.NoValueError
+			if errors.As(err, &noVal) && field.Type.Kind() == reflect.Struct {
+				if err := populateDefaults(patch, fieldVal.Addr()); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		fieldVal.Set(reflect.ValueOf(val))
+		fmt.Println(field.Name, " => ", val)
+	}
+	return nil
+}
+
 func ParseConfig(configPath string, configStruct Config) (*Config, error) {
 	patch := patchpanel.NewPatchPanel(patchpanel.TokenSeparator, patchpanel.KeyValueSeparator)
 
-	// get defaults off of our struct using patchpanel
-	confType := reflect.TypeOf(configStruct)
-	for i := 0; i < confType.NumField(); i++ {
-		fieldVal, err := patch.GetDefault(confType.Field(i).Name, confType, []string{})
-		if err != nil {
-			return &Config{}, err
-		}
-		fmt.Println(confType.Field(i).Name, " => ", fieldVal)
+	if err := populateDefaults(patch, reflect.ValueOf(&configStruct)); err != nil {
+		return &Config{}, err
 	}
 	return &configStruct, nil
 }
 
 func main() {
-	// grab a values/configuration file path from our environment using patchpanel
 	valuesFile := patchpanel.GetFileEnvOrPath(patchpanel.ENV_CONFIG_FILE, patchpanel.FLAG_CONFIG_FILE)
 	conf, err := ParseConfig(valuesFile, Config{})
 	if err != nil {
 		_, _ = os.Stderr.WriteString(fmt.Sprintf("error parsing configuration: %s\n", err.Error()))
 		os.Exit(1)
 	}
-	fmt.Println(conf)
+	fmt.Printf("%+v\n", *conf)
+
+	cfgType := patchpanel.ToReflectType(conf)
+	fmt.Println("Config type: ", cfgType)
 }

--- a/parser.go
+++ b/parser.go
@@ -58,10 +58,16 @@ var timeFormatMap = map[string]string{
 // for interpretation within a given function (see time.Time's parser in NewPatchPanel for an example implementation)
 type Parser func(value string, parserHints map[string]any) (any, error)
 
+// KindParser is like Parser but also receives the target reflect.Type, enabling it to handle
+// all types matching a given reflect.Kind (e.g. all struct types).  This is necessary because
+// a single KindParser must be able to construct a zero value of any type of that kind.
+type KindParser func(value string, toType reflect.Type, parserHints map[string]any) (any, error)
+
 type PatchPanel struct {
 	tokenSeparator    string
 	keyValueSeparator string
 	parsers           map[reflect.Type]Parser
+	kindParsers       map[reflect.Kind]KindParser
 	sync.RWMutex
 }
 
@@ -129,6 +135,20 @@ func NewPatchPanel(tokenSeparator string, keyValueSeparator string) *PatchPanel 
 				return val, nil
 			},
 		},
+		// kindParsers are a fallback for when no exact reflect.Type parser is registered.
+		// Type-specific parsers in parsers always take precedence.
+		kindParsers: map[reflect.Kind]KindParser{
+			// Struct fields with no registered type parser are handled by returning a zero
+			// value of the target type when a non-empty string is provided, or NoValueError
+			// when the tag value is empty (no default set).  Override via AddKindParser to
+			// support custom serialisation formats (e.g. JSON) for embedded struct defaults.
+			reflect.Struct: func(value string, toType reflect.Type, parserHints map[string]any) (any, error) {
+				if value == "" {
+					return nil, NoValueError{Msg: toType.Name()}
+				}
+				return reflect.New(toType).Elem().Interface(), nil
+			},
+		},
 	}
 	return pc
 }
@@ -138,6 +158,14 @@ func (pc *PatchPanel) AddParser(typ reflect.Type, parser Parser) {
 	pc.Lock()
 	defer pc.Unlock()
 	pc.parsers[typ] = parser
+}
+
+// AddKindParser adds a KindParser that is used as a fallback for all types matching the given
+// reflect.Kind when no exact reflect.Type parser is registered.  The ability to overwrite is intentional.
+func (pc *PatchPanel) AddKindParser(kind reflect.Kind, parser KindParser) {
+	pc.Lock()
+	defer pc.Unlock()
+	pc.kindParsers[kind] = parser
 }
 
 // ToReflectType is a shallow wrapper around reflect.TypeOf, placed in this library for reasons of code-flow
@@ -176,20 +204,27 @@ func parseHints(sF reflect.StructField, hints []string) map[string]any {
 // parserHints are optional and come in as a string from a tag name
 func (pc *PatchPanel) coerce(v string, toType reflect.Type, parserHints map[string]any) (any, error) {
 	pc.RLock()
-	parserFunc, ok := pc.parsers[toType]
+	parserFunc, typeOk := pc.parsers[toType]
+	kindParserFunc, kindOk := pc.kindParsers[toType.Kind()]
 	pc.RUnlock()
 
-	if !ok {
-		return nil, UnhandledParserTypeError{Msg: fmt.Sprintf("unknown type for parser: %v", reflect.TypeOf(v))}
+	if typeOk {
+		val, err := parserFunc(v, parserHints)
+		if err != nil {
+			return val, err
+		}
+		return val, nil
 	}
 
-	val, err := parserFunc(v, parserHints)
-	if err != nil {
-		// return whatever type parserFunc uses
-		return val, err
+	if kindOk {
+		val, err := kindParserFunc(v, toType, parserHints)
+		if err != nil {
+			return val, err
+		}
+		return val, nil
 	}
 
-	return val, nil
+	return nil, UnhandledParserTypeError{Msg: fmt.Sprintf("unknown type for parser: %v", toType)}
 }
 
 // GetFieldTag loads a tag off of a given field in a struct.

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,6 +9,21 @@ import (
 	"time"
 )
 
+type NestedConfig struct {
+	Host string `default:"localhost"`
+	Port int    `default:"5432"`
+}
+
+type TestStructWithNested struct {
+	Name   string       `default:"service"`
+	Config NestedConfig
+}
+
+type TestStructWithAnonymous struct {
+	Name string `default:"service"`
+	NestedConfig
+}
+
 type TestStruct struct {
 	Port           int           `default:"1357"`
 	Greeting       string        `friendly:"howdy"`
@@ -265,9 +280,56 @@ func Test_getFieldTag(t *testing.T) {
 			wantErr:            true,
 			parserHintLocation: "timeFormat",
 		},
+		{
+			name: "named struct field with no default tag returns NoValueError via struct KindParser",
+			args: args{
+				fieldName: "Config",
+				tagName:   "default",
+				t:         ToReflectType(TestStructWithNested{}),
+			},
+			want: reflect.StructField{
+				Name: "Config",
+				Type: ToReflectType(NestedConfig{}),
+				Tag:  "",
+			},
+			want1:   nil,
+			wantErr: true,
+		},
+		{
+			name: "anonymous embedded struct field with no default tag returns NoValueError via struct KindParser",
+			args: args{
+				fieldName: "NestedConfig",
+				tagName:   "default",
+				t:         ToReflectType(TestStructWithAnonymous{}),
+			},
+			want: reflect.StructField{
+				Name: "NestedConfig",
+				Type: ToReflectType(NestedConfig{}),
+				Tag:  "",
+			},
+			want1:   nil,
+			wantErr: true,
+		},
+		{
+			name: "named struct field with default tag returns zero value via struct KindParser",
+			args: args{
+				fieldName: "Config",
+				tagName:   "default",
+				t:         ToReflectType(struct{ Config NestedConfig `default:"something"` }{}),
+			},
+			want: reflect.StructField{
+				Name: "Config",
+				Type: ToReflectType(NestedConfig{}),
+				Tag:  `default:"something"`,
+			},
+			want1:   NestedConfig{},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// use a fresh pp per sub-test so AddKindParser tests in Test_getFieldTag
+			// cannot contaminate each other; the shared pp is still fine here.
 			got, got1, err := pp.GetFieldTag(tt.args.fieldName, tt.args.tagName, tt.args.t, []string{tt.parserHintLocation})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getFieldTag() error = %v, wantErr %v", err, tt.wantErr)
@@ -293,5 +355,43 @@ func Test_getFieldTag(t *testing.T) {
 				t.Errorf("getFieldTag() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
+	}
+}
+
+func TestAddKindParser(t *testing.T) {
+	pp := NewPatchPanel(TokenSeparator, KeyValueSeparator)
+
+	sentinel := NestedConfig{Host: "sentinel", Port: 9999}
+
+	// override the default struct KindParser with one that always returns a sentinel value
+	pp.AddKindParser(reflect.Struct, func(value string, toType reflect.Type, parserHints map[string]any) (any, error) {
+		if toType != ToReflectType(NestedConfig{}) {
+			return nil, errors.New("unexpected type in test KindParser")
+		}
+		return sentinel, nil
+	})
+
+	_, got, err := pp.GetFieldTag("Config", "default", ToReflectType(struct {
+		Config NestedConfig `default:"anything"`
+	}{}), []string{})
+	if err != nil {
+		t.Fatalf("AddKindParser: unexpected error: %v", err)
+	}
+	if got != sentinel {
+		t.Errorf("AddKindParser: got %v, want %v", got, sentinel)
+	}
+}
+
+func TestNoValueErrorFromStructKindParser(t *testing.T) {
+	pp := NewPatchPanel(TokenSeparator, KeyValueSeparator)
+
+	_, err := pp.GetDefault("Config", ToReflectType(TestStructWithNested{}), []string{})
+	if err == nil {
+		t.Fatal("expected NoValueError for struct field with no default tag, got nil")
+	}
+
+	var noVal NoValueError
+	if !errors.As(err, &noVal) {
+		t.Errorf("expected NoValueError, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
patchpanel 1.0.1 and before did not support embedded structs.  this adds support for reflect.Kind types.

An example is included as well.